### PR TITLE
Using the WP constant for the plugin folder

### DIFF
--- a/rentman.php
+++ b/rentman.php
@@ -41,14 +41,14 @@
               require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
             }
             foreach($active_plugins as $plugin){
-              if($plugin == 'wordpress-seo/wp-seo.php'){
-                $plugin_data = $plugin_data = get_plugin_data(WP_PLUGIN_DIR . '/' . $plugin);
+              if($plugin == 'wordpress-seo/wp-seo.php' || $plugin == 'wordpress-seo-premium/wp-seo-premium.php'){
+                $plugin_data = get_plugin_data(WP_PLUGIN_DIR . '/' . $plugin);
                 $yoastversion = $plugin_data['Version'];
                 $yoastversioncheck = explode(".", $yoastversion);
                 $yoastversioncheck = intval($yoastversion[0]);
               }
               if($plugin == 'woocommerce/woocommerce.php'){
-                $plugin_data = $plugin_data = get_plugin_data(WP_PLUGIN_DIR . '/' . $plugin);
+                $plugin_data = get_plugin_data(WP_PLUGIN_DIR . '/' . $plugin);
                 $woocommerceversion = $plugin_data['Version'];
                 $woocommerceversioncheck = explode('.', $woocommerceversion);
                 $woocommerceversioncheck = intval($woocommerceversioncheck[0] . substr($woocommerceversioncheck[1],0,1));

--- a/rentman.php
+++ b/rentman.php
@@ -42,13 +42,13 @@
             }
             foreach($active_plugins as $plugin){
               if($plugin == 'wordpress-seo/wp-seo.php'){
-                $plugin_data = get_plugin_data(ABSPATH . 'wp-content/plugins/' . $plugin);
+                $plugin_data = $plugin_data = get_plugin_data(WP_PLUGIN_DIR . '/' . $plugin);
                 $yoastversion = $plugin_data['Version'];
                 $yoastversioncheck = explode(".", $yoastversion);
                 $yoastversioncheck = intval($yoastversion[0]);
               }
               if($plugin == 'woocommerce/woocommerce.php'){
-                $plugin_data = get_plugin_data(ABSPATH . 'wp-content/plugins/' . $plugin);
+                $plugin_data = $plugin_data = get_plugin_data(WP_PLUGIN_DIR . '/' . $plugin);
                 $woocommerceversion = $plugin_data['Version'];
                 $woocommerceversioncheck = explode('.', $woocommerceversion);
                 $woocommerceversioncheck = intval($woocommerceversioncheck[0] . substr($woocommerceversioncheck[1],0,1));


### PR DESCRIPTION
I replaced the hard reference to the plugins folder to a Wordpress constant so it works with https://roots.io/sage/ or other Wordpress setups.